### PR TITLE
Now the user can deside in .env if he wants to see the browser or not…

### DIFF
--- a/src/browser_utils.py
+++ b/src/browser_utils.py
@@ -38,7 +38,7 @@ async def create_browser_context(playwright):
     context = await playwright.chromium.launch_persistent_context(
         user_data_dir=config.USER_DATA_DIR,
         channel="chrome",  # <--- FORCE REAL CHROME
-        headless=False, 
+        headless=not config.BROWSER_SHOW,  # BROWSER_SHOW=False → headless=True
         args=[
             "--disable-blink-features=AutomationControlled",
             "--disable-dev-shm-usage",

--- a/src/config.py
+++ b/src/config.py
@@ -100,3 +100,7 @@ AI_STUDIO_URL = "https://aistudio.google.com/app/prompts/new_chat"
 # --- TEST MODE ---
 TEST_MODE = False  
 TEST_ORDERS = []
+
+# --- BROWSER SETTINGS ---
+# Set to False to run browser in headless mode (hidden)
+BROWSER_SHOW = os.getenv("BROWSER_SHOW", "true").lower() == "true"


### PR DESCRIPTION
…. If the user desides to hide the browser,

then you want to add BROWSER_SHOW=false to .env, if the variable is not existing then the browser also will be showing up!

So that the user can deside if he want to get interupped by the browser!

Could be buggy or not work at all.

Done by: @seesee010